### PR TITLE
Updated hapi to version 10.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "chalk": "1.1.1",
-    "hapi": "10.1.0",
+    "hapi": "10.4.0",
     "joiify": "0.0.5",
     "lodash": "3.10.1"
   },


### PR DESCRIPTION
:rocket:

hapi just published version 10.4.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 59 commits (ahead by 59, behind by 0).
- [21983e0](https://github.com/hapijs/hapi/commit/21983e082780968736936c0e5f50e362d631f36a): Fix default host header. Closes #2824. Closes #2828
- [8ae7005](https://github.com/hapijs/hapi/commit/8ae70053712ad41f9140edb5a130d4a48b5c75bc): Throw when calling single connection methods. Closes #2819
- [ae2c280](https://github.com/hapijs/hapi/commit/ae2c280f48aa5ccd8ba60537521f5f4e98af11d2): Route level and plugin level extensions. Closes #2566
- [6f8374f](https://github.com/hapijs/hapi/commit/6f8374f0ec8c4c2a4460e0c1acd662baa9c27c6a): Support server.ext(events). Closes #2827
- [b37dc3e](https://github.com/hapijs/hapi/commit/b37dc3e2ed4e08621db5972c1013394741deb5ce): update topo. Closes #2826
- [7ee7cc1](https://github.com/hapijs/hapi/commit/7ee7cc1ba1abcae95bffc198323c1e140e0e617f): Allow unknown attributes
- [dc2c9a9](https://github.com/hapijs/hapi/commit/dc2c9a95973942655010d93020269212c9462363): Refactor extensions
- [e5d9cda](https://github.com/hapijs/hapi/commit/e5d9cda0de303fe71cc3307eb731a272d0eb4fc9): Relax plugin schema. Closes #2822
- [cab99e0](https://github.com/hapijs/hapi/commit/cab99e086c4b7ec52167200f1a526303f05bf664): Skip empty extention points in lifecycle. Closes #2823
- [7afc730](https://github.com/hapijs/hapi/commit/7afc730bfde2281dea98bc9e0458a0479a7c89e4): Plugin once attribute. Closes #2818
- [e799439](https://github.com/hapijs/hapi/commit/e7994395247c3cedb757203072baaf1cee34e8c2): add connection inside plugin. Closes #2754
- [9a8ab52](https://github.com/hapijs/hapi/commit/9a8ab527f25859296394e216a396657aea91db39): Update API.md
- [25f6d1b](https://github.com/hapijs/hapi/commit/25f6d1bac3b0876c47af29a7c11b7cb1c349b762): Update API.md
- [fc2f49d](https://github.com/hapijs/hapi/commit/fc2f49de5895963af494d5fa3a3f7010ffb294b5): 10.2.1
- [e157ba6](https://github.com/hapijs/hapi/commit/e157ba6181d9088d49b6212c941683186366697f): Document adding connection from plugin. Closes #2754

There are 59 commits in total. See the [full diff](https://github.com/hapijs/hapi/compare/c2f67521561d63610b2ab3e031d895dd049c1dbb...21983e082780968736936c0e5f50e362d631f36a).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
